### PR TITLE
radikale Änderung in Umleitung für Sprachen

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,8 +1,8 @@
 RewriteEngine On
 RewriteBase /
-DirectorySlash Off
-RewriteCond %{REQUEST_FILENAME} -d
-RewriteRule ^(.*[^/])$ /$1/ [L,R]
+#DirectorySlash On
+#RewriteCond %{REQUEST_FILENAME} -d
+#RewriteRule ^(.*[^/])$ /$1/ [L,R]
 RewriteRule ^(.*)/$ /$1 [L]
 RewriteCond %{REQUEST_FILENAME}.php -f
 RewriteRule ^(.+)$ /$1.php [L]

--- a/.htaccess
+++ b/.htaccess
@@ -1,20 +1,12 @@
 RewriteEngine On
 RewriteBase /
-#DirectorySlash On
-#RewriteCond %{REQUEST_FILENAME} -d
-#RewriteRule ^(.*[^/])$ /$1/ [L,R]
-RewriteRule ^(.*)/$ /$1 [L]
+DirectorySlash On
 RewriteCond %{REQUEST_FILENAME}.php -f
 RewriteRule ^(.+)$ /$1.php [L]
-RewriteCond %{QUERY_STRING} !lang=
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule ^(.+?)(/.*)?$ $2?lang=$1 [QSA,PT,L]
-RewriteCond %{REQUEST_FILENAME} -d
-RewriteRule ^(.*)$ /$1/index.php [L]
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^.*$ /not-found.php [L]
+
 <filesMatch "\.(jpe?g|png|gif|ico|svg)$">
 Header set Cache-Control "max-age=2628000, public"
 </filesMatch>

--- a/not-found.php
+++ b/not-found.php
@@ -1,4 +1,7 @@
 <?php
+// erst versuchen, zu richtiger Datei zu vermitteln
+
+
 require_once 'analytics.php';
 require_once 'translate.php';
 ?><!DOCTYPE html>

--- a/not-found.php
+++ b/not-found.php
@@ -1,6 +1,38 @@
 <?php
 // erst versuchen, zu richtiger Datei zu vermitteln
-
+$urip=explode('/',$_SERVER['REQUEST_URI']);
+// Array säubern
+$urip=array_values(array_filter($urip,function($value){return $value !== '';}));
+// mögliche Ursache: Anfrage enthält Sprache
+if(preg_match('~^[a-z]{2}(-[a-z]{2})*$~i',$urip[0])){
+	// Umleitung 'hinter den Kulissen'
+	// Sprache in GET-Parameter einfangen
+	$_GET['lang']=$urip[0];
+	// Pfad finden
+	array_shift($urip);
+	$path=$_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.implode(DIRECTORY_SEPARATOR,$urip);
+	if(file_exists($path)){
+		if(is_dir($path)){
+			chdir($path);
+			// find index file
+			$files=scandir($path);
+			foreach ($files as $f) {
+				if(substr($f,0,5)=='index'){
+					$path.=DIRECTORY_SEPARATOR.$f;
+					break;
+				}
+			}
+			$_SERVER['SCRIPT_NAME']=substr($path,strlen($home));
+			include $path;
+			exit;
+		}else{
+			chdir(substr($path,0,strrpos($path,'/')));
+			$_SERVER['SCRIPT_NAME']=substr($path,strlen($home)-1);
+			include $path;
+			exit;
+		}
+	}
+}
 
 require_once 'analytics.php';
 require_once 'translate.php';


### PR DESCRIPTION
Die Umleitung für die Sprachen wird jetzt nicht mehr in `.htaccess` vollführt, sondern in `not-found.php`.
Es ist einfacher, diese doch recht komplexe Weiterleitung *hinter den Kulissen* in PHP zu vollziehen.