### PR TITLE
schönere URLs für die Details-Seite

### DIFF
--- a/not-found.php
+++ b/not-found.php
@@ -72,6 +72,13 @@ if(file_exists($path.'.php')){
 	$_SERVER['SCRIPT_NAME']="komponist-info.php";
 	include 'komponist-info.php';
 	exit;
+}elseif(strtolower($urip[0])=='suche'&&strtolower($urip[1])=='details'){
+	$_GET['id']=$urip[2];
+	// für Analytics
+	chdir("suche");
+	$_SERVER['SCRIPT_NAME']="suche/details.php";
+	include 'details.php';
+	exit;
 }
 
 require_once 'translate.php';

--- a/not-found.php
+++ b/not-found.php
@@ -74,6 +74,7 @@ if(file_exists($path.'.php')){
 	exit;
 }elseif(strtolower($urip[0])=='suche'&&strtolower($urip[1])=='details'){
 	$_GET['id']=$urip[2];
+	$_GET['rewrite']=true;
 	// für Analytics
 	chdir("suche");
 	$_SERVER['SCRIPT_NAME']="suche/details.php";

--- a/suche/details.php
+++ b/suche/details.php
@@ -3,6 +3,8 @@ require_once "../translate.php";
 if(empty($_GET['id'])){
 	header("Location: /$use_lang/suche");
 	exit;
+}elseif(empty($_GET['rewrite'])){
+	header("Location: /$use_lang/suche/details/$_GET[id]");
 }
 require_once "misc.php";
 ?>

--- a/suche/details.php
+++ b/suche/details.php
@@ -132,7 +132,20 @@ require_once "misc.php";
 										<span><?php echo __('db');?></span>
 										<h2>Details</h2>
 										<p class="fh5co-lead"><?php
-										if((int)$_GET['id']>0){
+										if(!ctype_digit($_GET['id'])){
+											// Es handelt sich wahrscheinlich um eine Signatur
+											$sig=stripSig($_GET['id']);
+											// ID der zugehörigen Signatur finden
+											if($sig){
+												$res=mysqli_query($con,"SELECT ID FROM archivalien WHERE Signatur='$sig'");
+												if(mysqli_num_rows($res)){
+													$_GET['id']=mysqli_fetch_array($res,MYSQLI_NUM)[0];
+												}else{
+													$_GET['id']=0;
+												}
+											}
+										}
+										if(ctype_digit($_GET['id'])&&(int)$_GET['id']>0){
 											require_once "../analytics.php";
 											$res=mysqli_query($con,"SELECT * FROM archivalien LEFT JOIN komponisten ON komponisten.Name=archivalien.Komponist WHERE ID=$_GET[id]");
 											if($res&&mysqli_num_rows($res)>0){

--- a/suche/export.php
+++ b/suche/export.php
@@ -74,7 +74,7 @@ if(!empty($dsatz['Bemerkungen'])){
 }
 ?>					</did>
 					<otherfindaid>
-						<extref xlink:role="url_archivalunit" xlink:href="hsa.bplaced.de/suche/details.php?id=<?php echo $dsatz['ID'];?>">Titelaufnahme im Angebot des Archivs</extref>
+						<extref xlink:role="url_archivalunit" xlink:href="hsa.bplaced.de/suche/details/<?php echo formatSig($dsatz['Signatur']);?>">Titelaufnahme im Angebot des Archivs</extref>
 					</otherfindaid>
 					<odd>
 						<head>Anzahl</head>

--- a/suche/misc.php
+++ b/suche/misc.php
@@ -8,7 +8,11 @@ function formatSig($sig){
 }
 
 function stripSig($str){
-	return preg_replace('/([A-Z]{3})-([A-Z])-([0-9]{3})/i','\1\2\3',$str);
+	if(preg_match('/([A-Z]{3})-([A-Z])-([0-9]{3})/i',$str)){
+		return preg_replace('/([A-Z]{3})-([A-Z])-([0-9]{3})/i','\1\2\3',$str);
+	}else{
+		return false;
+	}
 }
 
 function translate_iso639_2B($langcode){

--- a/suche/search.php
+++ b/suche/search.php
@@ -146,11 +146,11 @@ if(isset($_GET['js'])){
 					<div class="col-md-8 col-md-offset-2 text-center animate-box">
 						<div class="about-content">
 							<center>
-							<div class="form-group" style="position: center">
-								<input type="submit" value="Beta Version" class="btn-lable">
-							</div>
-						</center>
-						<br>
+								<div class="form-group" style="position: center">
+									<input type="submit" value="Beta Version" class="btn-lable">
+								</div>
+							</center>
+							<br />
 <?php
 if(!isset($_GET['mode'])){
 	$s=$_GET['search'];
@@ -158,7 +158,7 @@ if(!isset($_GET['mode'])){
 	"OR Verfassungsdatum like '%$s%' OR Sprache like '%$s%' OR Anzahl like '%$s%' OR Sammlung like '%$s%'OR Standort like '%$s%' OR Signatur like '%".stripSig($s)."%'";
 	$res=mysqli_query($con,$sql);
 	while($dsatz=mysqli_fetch_assoc($res)){
-		echo "\t\t\t\t\t\t\t<blockquote><a href=\"details.php?id=".$dsatz['ID']."\"><p>".$dsatz['Titel']."<br><i>".$dsatz['Komponist']."</i></p></a></blockquote><br>\n";
+		echo "\t\t\t\t\t\t\t<blockquote><a href=\"details/".$dsatz['ID']."\"><p>".$dsatz['Titel']."<br><i>".$dsatz['Komponist']."</i></p></a></blockquote><br>\n";
 	}
 }else{
 	$res=mysqli_query($con,"DESCRIBE archivalien");
@@ -199,7 +199,7 @@ if(!isset($_GET['mode'])){
 }
 if(isset($_GET['search'])){
 ?>
-<a href="."><p>neue Suche</p></a>
+							<a href="."><p>neue Suche</p></a>
 <?php } ?>
 						</div>
 					</div>

--- a/suche/search.php
+++ b/suche/search.php
@@ -158,7 +158,7 @@ if(!isset($_GET['mode'])){
 	"OR Verfassungsdatum like '%$s%' OR Sprache like '%$s%' OR Anzahl like '%$s%' OR Sammlung like '%$s%'OR Standort like '%$s%' OR Signatur like '%".stripSig($s)."%'";
 	$res=mysqli_query($con,$sql);
 	while($dsatz=mysqli_fetch_assoc($res)){
-		echo "\t\t\t\t\t\t\t<blockquote><a href=\"details/".$dsatz['ID']."\"><p>".$dsatz['Titel']."<br><i>".$dsatz['Komponist']."</i></p></a></blockquote><br>\n";
+		echo "\t\t\t\t\t\t\t<blockquote><a href=\"details/".formatSig($dsatz['Signatur'])."\"><p>".$dsatz['Titel']."<br><i>".$dsatz['Komponist']."</i></p></a></blockquote><br>\n";
 	}
 }else{
 	$res=mysqli_query($con,"DESCRIBE archivalien");


### PR DESCRIPTION
Die URLs für `/suche/details.php` haben keinen sichtbaren GET-Parameter mehr (`details.php`**`?id=1`**), sondern die ID des Werkes erscheint wie eine Datei, also etwa `/suche/details/1`.